### PR TITLE
ci: specify aarch64-apple-darwin as bin2nix update target

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -52,7 +52,7 @@ jobs:
         run: nix flake update
 
       - name: bin2nix update
-        run: bin2nix update
+        run: bin2nix update --target aarch64-apple-darwin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `bin2nix update` がホスト OS を自動検出するため、Linux runner 上では `linux/amd64` の derivation を生成してしまっていた
- `--target aarch64-apple-darwin` を明示することで macOS arm64 向けの derivation が正しく生成されるようになる

## Test plan

- [ ] ワークフローを手動実行して `packages/*.nix` が `darwin_arm64` の URL を参照していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)