### PR TITLE
feat: restrict home-manager config to specific host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,24 @@
           })
         ];
       };
+
+      mkHome =
+        hostModules:
+        home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
+          modules = [
+            ./home-manager/base.nix
+            nix-index-database.homeModules.default
+          ] ++ hostModules;
+          extraSpecialArgs = {
+            inherit inputs localPackages;
+            anthropic-skills = inputs.anthropic-skills;
+            claude-code-guide-skills = inputs.claude-code-guide-skills;
+            superpowers-skills = inputs.superpowers-skills;
+            claude-plugins-official = inputs.claude-plugins-official;
+            claude-mem = inputs.claude-mem;
+          };
+        };
     in
     {
       # Build darwin flake using:
@@ -151,20 +169,8 @@
         specialArgs = { inherit inputs; };
       };
 
-      homeConfigurations."earlgray" = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
-        modules = [
-          ./home-manager/base.nix
-          nix-index-database.homeModules.default
-        ];
-        extraSpecialArgs = {
-          inherit inputs localPackages;
-          anthropic-skills = inputs.anthropic-skills;
-          claude-code-guide-skills = inputs.claude-code-guide-skills;
-          superpowers-skills = inputs.superpowers-skills;
-          claude-plugins-official = inputs.claude-plugins-official;
-          claude-mem = inputs.claude-mem;
-        };
-      };
+      homeConfigurations."earlgray@makabeee-macbook-air" = mkHome [
+        ./home-manager/hosts/makabeee-macbook-air.nix
+      ];
     };
 }

--- a/home-manager/hosts/makabeee-macbook-air.nix
+++ b/home-manager/hosts/makabeee-macbook-air.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+{
+  home.activation.checkHostname = lib.hm.dag.entryBefore [ "checkFilesChanged" ] ''
+    expected="earlgray@makabeee-macbook-air"
+    actual="$(whoami)@$(hostname -s)"
+    if [ "$actual" != "$expected" ]; then
+      echo "Error: this configuration is for $expected, but current host is $actual" >&2
+      exit 1
+    fi
+  '';
+}


### PR DESCRIPTION
## Summary

- `homeConfigurations` のキーを `"earlgray@makabeee-macbook-air"` に変更（`username@hostname` 形式）
- activation スクリプトで `$(whoami)@$(hostname -s)` をチェックし、別ホストでの誤適用を防止

## Test plan

- [ ] `home-manager build --flake ".#$(whoami)@$(hostname -s)"` が成功することを確認
- [ ] 別ホスト名環境では activation 時にエラーで止まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)